### PR TITLE
fix: remove `get-version` until there is a release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  get-version:
+  # get-version:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.clean_version.outputs.version }}
@@ -54,8 +54,8 @@ jobs:
     environment:
       name: infra/staging
       url: https://staging.cast.walletconnect.com/health
-    needs:
-      - get-version
+    # needs:
+    #   - get-version
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -95,7 +95,7 @@ jobs:
         env:
           GRAFANA_AUTH: ${{ steps.get-grafana-key.outputs.key }}
           TF_VAR_grafana_endpoint: ${{ steps.get-grafana-details.outputs.endpoint }}
-          TF_VAR_image_version: ${{ needs.get-version.outputs.version }}
+          # TF_VAR_image_version: ${{ needs.get-version.outputs.version }}
         with:
           environment: staging
 


### PR DESCRIPTION
# Description

Remove `get-version` from the CI since we don't have a release to work with yet.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
