### PR TITLE
feat: filtering by project_id -> collection(project_id)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "cast-server"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "async-trait",
  "axum",

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -9,8 +9,9 @@ pub struct Account(String);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ClientData {
+    #[serde(rename = "_id")]
     id: String,
-    project_id: String,
+    // project_id: String,
     relay_url: String,
     sym_key: String,
 }

--- a/src/handlers/notify.rs
+++ b/src/handlers/notify.rs
@@ -11,7 +11,10 @@ use {
     hyper::HeaderMap,
     mongodb::bson::doc,
     serde::{Deserialize, Serialize},
-    std::{collections::HashMap, sync::Arc},
+    std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+    },
     tokio_stream::StreamExt,
 };
 
@@ -64,9 +67,9 @@ pub struct JsonRpcPayload {
 // Change String to Error
 #[derive(Serialize, Deserialize)]
 struct Response {
-    sent: Vec<String>,
-    failed: Vec<(String, String)>,
-    not_found: Vec<String>,
+    sent: HashSet<String>,
+    failed: HashSet<(String, String)>,
+    not_found: HashSet<String>,
 }
 
 pub async fn handler(
@@ -88,17 +91,22 @@ pub async fn handler(
         .collect::<Vec<String>>();
 
     let mut cursor = db
-        .collection::<ClientData>("clients")
+        .collection::<ClientData>(project_id)
         .find(
-            doc! { "project_id":project_id, "id": {"$in": &accounts}},
+            // doc! { "project_id":project_id, "id": {"$in": &accounts}},
+            doc! { "_id": {"$in": &accounts}},
             None,
         )
         .await
         .unwrap();
 
+    let mut not_found: HashSet<String> = accounts.into_iter().collect();
+
     let mut clients = HashMap::<String, Vec<(String, String)>>::new();
 
     while let Some(data) = cursor.try_next().await.unwrap() {
+        not_found.remove(&data.id);
+
         let encryption_key = hex::decode(&data.sym_key).unwrap();
         let encrypted_notification = {
             let cipher =
@@ -133,8 +141,8 @@ pub async fn handler(
             .push((message, data.id));
     }
 
-    let mut confirmed_sends = vec![];
-    let mut failed_sends = vec![];
+    let mut confirmed_sends = HashSet::new();
+    let mut failed_sends = HashSet::new();
     for (url, notifications) in clients {
         let token = jwt_token(&url, &state.keypair);
         let relay_query = format!("auth={token}&projectId={project_id}");
@@ -150,31 +158,33 @@ pub async fn handler(
                 Ok(connection) => {
                     let ws = &mut connection.0;
                     match ws.write_message(tungstenite::Message::Text(encrypted_notification)) {
-                        Ok(_) => confirmed_sends.push(sender),
+                        Ok(_) => {
+                            confirmed_sends.insert(sender);
+                        }
                         Err(e) => {
-                            failed_sends.push((sender, e.to_string()));
+                            failed_sends.insert((sender, e.to_string()));
                         }
                     };
                 }
-                Err(e) => failed_sends.push((
-                    sender,
-                    format!(
-                        "Failed connecting to {}://{}",
-                        &url.scheme(),
-                        &url.host().unwrap()
-                    ),
-                )),
+                Err(e) => {
+                    failed_sends.insert((
+                        sender,
+                        format!(
+                            "Failed connecting to {}://{}",
+                            &url.scheme(),
+                            &url.host().unwrap()
+                        ),
+                    ));
+                }
             }
         }
     }
 
-    dbg!("Sent");
-    let not_found: Vec<String> = accounts
-        .into_iter()
-        .filter(|account| !confirmed_sends.contains(account))
-        //TODO: Fix this
-        // .filter(|account| !failed_sends.contains(account))
-        .collect();
+    // .into_iter()
+    // .filter(|account| !confirmed_sends.contains(account))
+    // //TODO: Fix this
+    // // .filter(|account| !failed_sends.contains(account))
+    // .collect();
 
     // Get them into one struct and serialize as json
     let response = Response {
@@ -184,7 +194,6 @@ pub async fn handler(
     };
     let response_json = serde_json::to_string(&response).unwrap();
 
-    dbg!("Donzo");
     (StatusCode::OK, response_json)
 }
 

--- a/src/handlers/register.rs
+++ b/src/handlers/register.rs
@@ -33,12 +33,12 @@ pub async fn handler(
     let insert_data = ClientData {
         id: data.account.0.clone(), // format!("{}:{}", project_id, data.account.0)?,
         // TODO: This needs auth so that malicious user cannot add client's to other projects
-        project_id: project_id.to_string(), // project_id.to_string(),
+        // project_id: project_id.to_string(), // project_id.to_string(),
         relay_url: data.relay_url,
         sym_key: data.sym_key,
     };
 
-    db.collection::<ClientData>("clients")
+    db.collection::<ClientData>(project_id)
         .insert_one(insert_data, None)
         .await
         .unwrap();


### PR DESCRIPTION
# Description

Moving logic from filtering both by client id and project id in one collection, to separate collections for project_id, so that we have no repeated client_id's for one project.

