### PR TITLE
fix(o11y): alarms not configured properly

### DIFF
--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -744,11 +744,7 @@ resource "grafana_dashboard" "at_a_glance" {
             "message" : "Cast failing to send messages, potential problem with Cast <-> Relay communication.",
             "name" : "${var.environment} Cast failing on send (communicating with relay)",
             "noDataState" : "no_data",
-            "notifications" : [
-              {
-                "uid" : "l_iaPw6nk"
-              }
-            ]
+            "notifications" : local.notifications
           },
           "datasource" : {
             "type" : "prometheus",
@@ -1015,11 +1011,7 @@ resource "grafana_dashboard" "at_a_glance" {
             "message" : "Cast is sending too much 4XX messages",
             "name" : "${var.environment} Cast Server 4XX alert",
             "noDataState" : "no_data",
-            "notifications" : [
-              {
-                "uid" : "l_iaPw6nk"
-              }
-            ]
+            "notifications" : local.notifications
           },
           "datasource" : {
             "type" : "cloudwatch",
@@ -1212,7 +1204,7 @@ resource "grafana_dashboard" "at_a_glance" {
             "message" : "Cast throwing multiple  5xx errors.",
             "name" : "${var.environment} Cast Server 5XX alert",
             "noDataState" : "no_data",
-            "notifications" : []
+            "notifications" : local.notifications
           },
           "datasource" : {
             "type" : "cloudwatch",


### PR DESCRIPTION
# Description

Two problems:
* 5xx alarms not notifying opsgenie
* 4xx alarms also paging for staging

## How Has This Been Tested?

Not tested (hotfix)

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
