### PR TITLE
fix: missing env var in integration tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,3 +34,4 @@ jobs:
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           ENVIRONMENT: ${{ inputs.environment }}
+          TEST_PROJECT_ID: ${{ secrets.TEST_PROJECT_ID }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,6 +32,5 @@ jobs:
       - name: Run integration tests
         run: cargo test --test integration
         env:
-          PROJECT_ID: ${{ secrets.PROJECT_ID }}
           ENVIRONMENT: ${{ inputs.environment }}
           TEST_PROJECT_ID: ${{ secrets.TEST_PROJECT_ID }}


### PR DESCRIPTION
# Description

Integration tests fail as they are missing TEST_PROJECT_ID environment variable. 
Added it to the workflow.

## How Has This Been Tested?

Ran locally with only those env vars and tests pass.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
