### PR TITLE
fix: change default type to subscribe all subscriptions

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -53,7 +53,7 @@ pub struct SubscriptionAuth {
 }
 
 fn default_scope() -> String {
-    "v1".to_string()
+    "gm_hourly".to_string()
 }
 
 fn default_act() -> String {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -52,10 +52,14 @@ pub struct SubscriptionAuth {
     pub scp: String,
 }
 
+// TODO: Remove this as soon as wc_pushRequest -> wc_pushSubscribe migration is
+// done
 fn default_scope() -> String {
     "gm_hourly".to_string()
 }
 
+// TODO: Remove this as soon as wc_pushRequest -> wc_pushSubscribe migration is
+// done
 fn default_act() -> String {
     "push_subscription".to_string()
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,7 +38,7 @@ pub struct ClientData {
 
 fn default_scope() -> HashSet<String> {
     let mut scope = HashSet::with_capacity(1);
-    scope.insert("v1".into());
+    scope.insert("gm_hourly".into());
     scope
 }
 
@@ -177,5 +177,5 @@ pub struct Notification {
 }
 
 fn default_notification_type() -> String {
-    "v1".to_string()
+    "gm_hourly".to_string()
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -36,6 +36,8 @@ pub struct ClientData {
     pub scope: HashSet<String>,
 }
 
+// TODO: Remove this as soon as wc_pushRequest -> wc_pushSubscribe migration is
+// done
 fn default_scope() -> HashSet<String> {
     let mut scope = HashSet::with_capacity(1);
     scope.insert("gm_hourly".into());
@@ -176,6 +178,8 @@ pub struct Notification {
     pub r#type: String,
 }
 
+// TODO: Remove this as soon as wc_pushRequest -> wc_pushSubscribe migration is
+// done
 fn default_notification_type() -> String {
     "gm_hourly".to_string()
 }


### PR DESCRIPTION
# Description

All new subscriptions need to specify the scope (as well as all notify calls should include type).
The current `default` usage is only here to support GM app, and will be removed as soon as `wc_pushRequest` flow is removed.

This changes the default value to hotfix current mid-transition problems.

## How Has This Been Tested?

Sent notification to myself.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
