### PR TITLE
feat: confirm ack with relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,6 +3248,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
+name = "relay_client"
+version = "0.1.0"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=1fb0f78f28f69b3f3d4f20330f90c8d877185874#1fb0f78f28f69b3f3d4f20330f90c8d877185874"
+dependencies = [
+ "chrono",
+ "futures-channel",
+ "futures-util",
+ "pin-project",
+ "relay_rpc",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "relay_rpc"
 version = "0.1.0"
 source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=1fb0f78f28f69b3f3d4f20330f90c8d877185874#1fb0f78f28f69b3f3d4f20330f90c8d877185874"
@@ -3605,6 +3626,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cac3f1e2ca2fe333923a1ae72caca910b98ed0630bb35ef6f8c8517d6e81afa"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -4087,6 +4119,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,6 +4535,7 @@ name = "walletconnect_sdk"
 version = "0.1.0"
 source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=1fb0f78f28f69b3f3d4f20330f90c8d877185874#1fb0f78f28f69b3f3d4f20330f90c8d877185874"
 dependencies = [
+ "relay_client",
  "relay_rpc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ futures = "0.3.26"
 async-tungstenite = {version = "0.20.0", features = ["tokio", "tokio-native-tls"]}
 dashmap = "5.4.0"
 
-walletconnect_sdk = { git = "https://github.com/WalletConnect/WalletConnectRust.git", features= ["rpc"], rev = "1fb0f78f28f69b3f3d4f20330f90c8d877185874"}
+walletconnect_sdk = { git = "https://github.com/WalletConnect/WalletConnectRust.git", features= ["full"], rev = "1fb0f78f28f69b3f3d4f20330f90c8d877185874"}
 x25519-dalek = { version = "2.0.0-rc.2" , features = ["static_secrets"]}
 hkdf = "0.12.3"
 sha2 = "0.10.6"

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,7 +55,13 @@ pub enum Error {
     WebSocket(#[from] tungstenite::Error),
 
     #[error(transparent)]
+    Broadcast(#[from] tokio::sync::broadcast::error::TryRecvError),
+
+    #[error(transparent)]
     FromUtf8Error(#[from] FromUtf8Error),
+
+    #[error(transparent)]
+    TokioTimeElapsed(#[from] tokio::time::error::Elapsed),
 
     #[error(transparent)]
     Base64Decode(#[from] base64::DecodeError),

--- a/src/handlers/subscribe_topic.rs
+++ b/src/handlers/subscribe_topic.rs
@@ -68,7 +68,7 @@ pub async fn handler(
 
             info!("Subscribing to project topic: {}", &topic);
             state
-                .webclient_tx
+                .wsclient_tx
                 .send(websocket_service::WebsocketMessage::Register(
                     topic.to_string(),
                 ))

--- a/src/state.rs
+++ b/src/state.rs
@@ -22,8 +22,8 @@ pub struct AppState {
     pub metrics: Option<Metrics>,
     pub database: Arc<mongodb::Database>,
     pub keypair: Keypair,
-    pub webclient_keypair: Keypair,
-    pub webclient_tx: tokio::sync::mpsc::Sender<WebsocketMessage>,
+    pub wsclient_keypair: Keypair,
+    pub wsclient_tx: tokio::sync::mpsc::Sender<WebsocketMessage>,
 }
 
 build_info::build_info!(fn build_info);
@@ -33,8 +33,8 @@ impl AppState {
         config: Configuration,
         database: Arc<mongodb::Database>,
         keypair: Keypair,
-        webclient_keypair: Keypair,
-        webclient_tx: tokio::sync::mpsc::Sender<WebsocketMessage>,
+        wsclient_keypair: Keypair,
+        wsclient_tx: tokio::sync::mpsc::Sender<WebsocketMessage>,
     ) -> crate::Result<AppState> {
         let build_info: &BuildInfo = build_info();
 
@@ -44,8 +44,8 @@ impl AppState {
             metrics: None,
             database,
             keypair,
-            webclient_keypair,
-            webclient_tx,
+            wsclient_keypair,
+            wsclient_tx,
         })
     }
 
@@ -87,7 +87,7 @@ impl AppState {
             )
             .await?;
 
-        self.webclient_tx
+        self.wsclient_tx
             .send(WebsocketMessage::Register(topic))
             .await
             .map_err(|_| crate::error::Error::ChannelClosed)?;


### PR DESCRIPTION
# Description

Change `/notify` calls to wait for relays response and inform user of failures.

Resolves # (todo)

## How Has This Been Tested?

Still testing and debugging.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
