### PR TITLE
70 move casts notify from websockets to http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2810,7 +2810,7 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 [[package]]
 name = "relay_client"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.15.0#7b49fc420bb402e8793b6fc0caeca5d4ba9d194e"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.17.0#cf52aa0a260c6b957078c34c0f173cd9ae0c4b5e"
 dependencies = [
  "chrono",
  "futures-channel",
@@ -2833,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "relay_rpc"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.15.0#7b49fc420bb402e8793b6fc0caeca5d4ba9d194e"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.17.0#cf52aa0a260c6b957078c34c0f173cd9ae0c4b5e"
 dependencies = [
  "bs58",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,8 @@ futures = "0.3.26"
 async-tungstenite = {version = "0.20.0", features = ["tokio", "tokio-native-tls"]}
 dashmap = "5.4.0"
 
-relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.15.0", features = ["cacao"]}
-relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.15.0" }
+relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.17.0", features = ["cacao"]}
+relay_client = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.17.0" }
 x25519-dalek = { version = "2.0.0-rc.2" , features = ["static_secrets"]}
 hkdf = "0.12.3"
 sha2 = "0.10.6"

--- a/src/handlers/notify.rs
+++ b/src/handlers/notify.rs
@@ -90,7 +90,13 @@ pub async fn handler(
 
     // Attempts to send to all found accounts, waiting for relay ack for
     // NOTIFY_TIMEOUT seconds
-    process_publish_jobs(jobs, state.wsclient.clone(), &mut response, request_id).await?;
+    process_publish_jobs(
+        jobs,
+        state.http_relay_client.clone(),
+        &mut response,
+        request_id,
+    )
+    .await?;
 
     info!("[{request_id}] Response: {response:?} for notify from project: {project_id}");
 
@@ -105,7 +111,7 @@ const NOTIFY_TIMEOUT: u64 = 45;
 
 async fn process_publish_jobs(
     jobs: Vec<PublishJob>,
-    client: Arc<relay_client::websocket::Client>,
+    client: Arc<relay_client::http::Client>,
     response: &mut Response,
     request_id: uuid::Uuid,
 ) -> Result<()> {
@@ -120,6 +126,7 @@ async fn process_publish_jobs(
                 job.message,
                 4002,
                 Duration::from_secs(86400),
+                true,
             ),
         )
         .map(|result| match result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use {
     opentelemetry::{sdk::Resource, KeyValue},
     rand::prelude::*,
     relay_rpc::auth::ed25519_dalek::Keypair,
-    std::{net::SocketAddr, sync::Arc},
+    std::{net::SocketAddr, sync::Arc, time::Duration},
     tokio::{select, sync::broadcast},
     tower::ServiceBuilder,
     tower_http::{
@@ -68,9 +68,15 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Configurati
 
     let connection_handler = wsclient::RelayConnectionHandler::new("cast-client", tx);
     let wsclient = Arc::new(relay_client::websocket::Client::new(connection_handler));
+    let http_client = Arc::new(create_http_client(
+        &keypair,
+        &config.relay_url.replace("ws", "http"),
+        &config.cast_url,
+        &config.project_id,
+    ));
 
     // Creating state
-    let mut state = AppState::new(config, db, keypair, wsclient.clone())?;
+    let mut state = AppState::new(config, db, keypair, wsclient.clone(), http_client)?;
 
     // Telemetry
     if state.config.telemetry_prometheus_port.is_some() {
@@ -158,4 +164,25 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Configurati
     }
 
     Ok(())
+}
+
+fn create_http_client(
+    key: &Keypair,
+    http_relay_url: &str,
+    cast_url: &str,
+    project_id: &str,
+) -> relay_client::http::Client {
+    let rpc_address = format!("{http_relay_url}/rpc");
+    let aud_address = format!("{http_relay_url}");
+
+    let auth = relay_rpc::auth::AuthToken::new(cast_url)
+        .aud(aud_address)
+        .ttl(Duration::from_secs(50 * 365 * 24 * 60 * 60))
+        .as_jwt(key)
+        .unwrap();
+
+    let conn_opts =
+        relay_client::ConnectionOptions::new(project_id, auth).with_address(rpc_address);
+
+    relay_client::http::Client::new(&conn_opts).unwrap()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,9 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Configurati
     Ok(())
 }
 
+// TODO: This is 50 years, only used temporarely untill the client is changed.
+const HTTP_CLIENT_TTL: u32 = 50 * 365 * 24 * 60 * 60;
+
 fn create_http_client(
     key: &Keypair,
     http_relay_url: &str,
@@ -177,7 +180,7 @@ fn create_http_client(
 
     let auth = relay_rpc::auth::AuthToken::new(cast_url)
         .aud(aud_address)
-        .ttl(Duration::from_secs(50 * 365 * 24 * 60 * 60))
+        .ttl(Duration::from_secs(HTTP_CLIENT_TTL))
         .as_jwt(key)
         .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ fn create_http_client(
     project_id: &str,
 ) -> relay_client::http::Client {
     let rpc_address = format!("{http_relay_url}/rpc");
-    let aud_address = format!("{http_relay_url}");
+    let aud_address = http_relay_url.to_string();
 
     let auth = relay_rpc::auth::AuthToken::new(cast_url)
         .aud(aud_address)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Configurati
 }
 
 // TODO: This is 50 years, only used temporarely untill the client is changed.
-const HTTP_CLIENT_TTL: u32 = 50 * 365 * 24 * 60 * 60;
+const HTTP_CLIENT_TTL: u64 = 50 * 365 * 24 * 60 * 60;
 
 fn create_http_client(
     key: &Keypair,

--- a/src/state.rs
+++ b/src/state.rs
@@ -22,6 +22,7 @@ pub struct AppState {
     pub database: Arc<mongodb::Database>,
     pub keypair: Keypair,
     pub wsclient: Arc<relay_client::websocket::Client>,
+    pub http_relay_client: Arc<relay_client::http::Client>,
 }
 
 build_info::build_info!(fn build_info);
@@ -32,6 +33,7 @@ impl AppState {
         database: Arc<mongodb::Database>,
         keypair: Keypair,
         wsclient: Arc<relay_client::websocket::Client>,
+        http_relay_client: Arc<relay_client::http::Client>,
     ) -> crate::Result<AppState> {
         let build_info: &BuildInfo = build_info();
 
@@ -42,6 +44,7 @@ impl AppState {
             database,
             keypair,
             wsclient,
+            http_relay_client,
         })
     }
 

--- a/src/websocket_service/handlers/push_subscribe.rs
+++ b/src/websocket_service/handlers/push_subscribe.rs
@@ -85,6 +85,7 @@ pub async fn handle(
             base64_notification,
             4007,
             Duration::from_secs(86400),
+            false,
         )
         .await?;
 

--- a/src/websocket_service/handlers/push_update.rs
+++ b/src/websocket_service/handlers/push_update.rs
@@ -78,6 +78,7 @@ pub async fn handle(
             base64_notification,
             4009,
             Duration::from_secs(86400),
+            false,
         )
         .await?;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -152,6 +152,7 @@ PROJECT_ID to be set",
             message,
             4006,
             Duration::from_secs(86400),
+            false,
         )
         .await
         .unwrap();
@@ -250,11 +251,10 @@ PROJECT_ID to be set",
     });
 
     let delete_message = json! ({
-        "id": id,
-        "jsonrpc": "2.0",
-        "params":
-base64::engine::general_purpose::STANDARD.encode(delete_params.to_string().
-as_bytes())     });
+            "id": id,
+            "jsonrpc": "2.0",
+            "params": base64::engine::general_purpose::STANDARD.encode(delete_params.to_string().as_bytes())
+    });
 
     let envelope = Envelope::<EnvelopeType0>::new(&response_topic_key, delete_message).unwrap();
 
@@ -266,6 +266,7 @@ as_bytes())     });
             encoded_message,
             4004,
             Duration::from_secs(86400),
+            false,
         )
         .await
         .unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,16 +1,11 @@
 use {
     crate::context::encode_subscription_auth,
-    cast_server::wsclient::RelayClientEvent,
-    std::{sync::Arc, time::Duration},
-};
-use {
-    // crate::context::encode_subscription_auth,
     base64::Engine,
     cast_server::{
         auth::SubscriptionAuth,
         types::{Envelope, EnvelopeType0, EnvelopeType1, Notification},
         websocket_service::{NotifyMessage, NotifyResponse},
-        wsclient,
+        wsclient::{self, RelayClientEvent},
     },
     chacha20poly1305::{
         aead::{generic_array::GenericArray, AeadMut},
@@ -25,6 +20,7 @@ use {
     },
     serde_json::json,
     sha2::Sha256,
+    std::{sync::Arc, time::Duration},
     x25519_dalek::{PublicKey, StaticSecret},
 };
 


### PR DESCRIPTION
# Description

Moves from websockets to HTTP for `/notify` to avoid rate limiting on notifying. 
Also fixing no PN, by specifying `prompt: true`

Resolves #70 

## How Has This Been Tested?

Tests passing, message arriving.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
