### PR TITLE
feat: add ECS panels and alerts

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -137,7 +137,7 @@ module "vpc" {
 module "o11y" {
   source = "./monitoring"
 
-  app_name                = "${terraform.workspace}-${local.app_name}"
+  app_name                = local.app_name
   prometheus_workspace_id = aws_prometheus_workspace.prometheus.id
   load_balancer_arn       = module.ecs.load_balancer_arn
   environment             = terraform.workspace

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -52,17 +52,21 @@ dashboard.new(
 )
 
 .addPanels(layout.generate_grid([
-  row.new('Database'),
-    panels.db.available_memory(ds, vars)          { gridPos: pos._2 },
-    panels.db.cpu(ds, vars)                       { gridPos: pos._2 },
-    panels.db.net_throughput(ds, vars)            { gridPos: pos._2 },
-    panels.db.write_latency(ds, vars)             { gridPos: pos._2 },
-
   row.new('Application'),
     panels.app.client_registrations(ds, vars)     { gridPos: pos._2 },
     panels.app.dispatched_notifications(ds, vars) { gridPos: pos._2 },
     panels.app.send_failed(ds, vars)              { gridPos: pos._2 },
     panels.app.account_not_found(ds, vars)        { gridPos: pos._2 },
+
+  row.new('ECS'),
+    panels.ecs.cpu(ds, vars)                      { gridPos: pos._2 },
+    panels.ecs.memory(ds, vars)                   { gridPos: pos._2 },
+
+  row.new('Database'),
+    panels.db.available_memory(ds, vars)          { gridPos: pos._2 },
+    panels.db.cpu(ds, vars)                       { gridPos: pos._2 },
+    panels.db.net_throughput(ds, vars)            { gridPos: pos._2 },
+    panels.db.write_latency(ds, vars)             { gridPos: pos._2 },
 
   row.new('Load Balancer'),
     panels.lb.requests(ds, vars)                  { gridPos: pos._1 },

--- a/terraform/monitoring/dashboard.tf
+++ b/terraform/monitoring/dashboard.tf
@@ -3,14 +3,14 @@ data "jsonnet_file" "dashboard" {
 
   ext_str = {
     dashboard_title = "${var.environment} - Cast Server"
-    dashboard_uid   = "${var.environment}-cast-server"
+    dashboard_uid   = "${var.environment}-${var.app_name}"
 
     prometheus_uid = grafana_data_source.prometheus.uid
     cloudwatch_uid = grafana_data_source.cloudwatch.uid
 
     environment      = var.environment
     notifications    = jsonencode(local.notifications)
-    ecs_service_name = "${var.environment}-cast-keystore-docdb-primary-cluster"
+    ecs_service_name = "${var.environment}-${var.app_name}-service"
     load_balancer    = local.load_balancer
     docdb_cluster_id = var.document_db_cluster_id
   }

--- a/terraform/monitoring/panels/ecs/cpu.libsonnet
+++ b/terraform/monitoring/panels/ecs/cpu.libsonnet
@@ -1,0 +1,45 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+local overrides = defaults.overrides;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'CPU Utilization',
+      datasource  = ds.cloudwatch,
+    )
+    .configure(overrides.cpu(defaults.configuration.timeseries_resource))
+
+    .setAlert(defaults.alerts.cpu(
+      namespace     = vars.namespace,
+      title         = 'ECS',
+      env           = vars.environment,
+      notifications = vars.notifications,
+    ))
+
+    .addTarget(targets.cloudwatch(
+      alias       = "CPU (${PROP('Stat')})",
+      datasource  = ds.cloudwatch,
+      namespace   = 'AWS/ECS',
+      metricName  = 'CPUUtilization',
+      dimensions  = {
+        ServiceName: vars.ecs_service_name
+      },
+      statistic   = 'Maximum',
+      refId       = 'CPU_Max',
+    ))
+    .addTarget(targets.cloudwatch(
+      alias       = "CPU (${PROP('Stat')})",
+      datasource  = ds.cloudwatch,
+      namespace   = 'AWS/ECS',
+      metricName  = 'CPUUtilization',
+      dimensions  = {
+        ServiceName: vars.ecs_service_name
+      },
+      statistic   = 'Average',
+      refId       = 'CPU_Avg',
+    ))
+}

--- a/terraform/monitoring/panels/ecs/memory.libsonnet
+++ b/terraform/monitoring/panels/ecs/memory.libsonnet
@@ -1,0 +1,44 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Memory Utilization',
+      datasource  = ds.cloudwatch,
+    )
+    .configure(defaults.overrides.memory(defaults.configuration.timeseries_resource))
+
+    .setAlert(defaults.alerts.memory(
+      namespace     = vars.namespace,
+      title         = 'ECS',
+      env           = vars.environment,
+      notifications = vars.notifications,
+    ))
+
+    .addTarget(targets.cloudwatch(
+      alias       = "Memory (${PROP('Stat')})",
+      datasource  = ds.cloudwatch,
+      namespace   = 'AWS/ECS',
+      metricName  = 'MemoryUtilization',
+      dimensions  = {
+        ServiceName: vars.ecs_service_name
+      },
+      statistic   = 'Maximum',
+      refId       = 'Mem_Max',
+    ))
+    .addTarget(targets.cloudwatch(
+      alias       = "Memory (${PROP('Stat')})",
+      datasource  = ds.cloudwatch,
+      namespace   = 'AWS/ECS',
+      metricName  = 'MemoryUtilization',
+      dimensions  = {
+        ServiceName: vars.ecs_service_name
+      },
+      statistic   = 'Average',
+      refId       = 'Mem_Avg',
+    ))
+}

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -11,6 +11,10 @@
     net_throughput:           (import 'db/net_throughput.libsonnet'             ).new,
     write_latency:            (import 'db/write_latency.libsonnet'              ).new,
   },
+  ecs: {
+    cpu:                      (import 'ecs/cpu.libsonnet'                       ).new,
+    memory:                   (import 'ecs/memory.libsonnet'                    ).new,
+  },
   lb: {
     requests:                 (import 'lb/requests.libsonnet'                   ).new,
     error_4xx:                (import 'lb/error_4xx.libsonnet'                  ).new,


### PR DESCRIPTION
# Description

Add panels for ECS `cpu` and `memory` metrics with associated alarms.
Resolves #37 

## How Has This Been Tested?

Manual run of `jsonnet`

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
