### PR TITLE
feat: add ELB and DocDB panels, remove no-data alerts for 4XX and 5XX

### DIFF
--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -1,4 +1,6 @@
 locals {
+  service_name = "${var.app_name}-service"
+
   file_descriptor_soft_limit = pow(2, 18)
   file_descriptor_hard_limit = local.file_descriptor_soft_limit * 2
 
@@ -124,7 +126,7 @@ resource "aws_ecs_task_definition" "app_task_definition" {
 
 ## Service
 resource "aws_ecs_service" "app_service" {
-  name            = "${var.app_name}-service"
+  name            = local.service_name
   cluster         = aws_ecs_cluster.app_cluster.id
   task_definition = aws_ecs_task_definition.app_task_definition.arn
   launch_type     = "FARGATE"

--- a/terraform/ecs/outputs.tf
+++ b/terraform/ecs/outputs.tf
@@ -1,3 +1,19 @@
+output "service_name" {
+  description = "The name of the service"
+  value       = local.service_name
+}
+
+output "target_group_arn" {
+  description = "The ARN of the target group"
+  value       = aws_lb_target_group.target_group.arn
+}
+
 output "load_balancer_arn" {
-  value = aws_lb.application_load_balancer.arn
+  description = "The ARN of the load balancer"
+  value       = aws_lb.application_load_balancer.arn
+}
+
+output "load_balancer_arn_suffix" {
+  description = "The ARN suffix of the load balancer"
+  value       = aws_lb.application_load_balancer.arn_suffix
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -140,7 +140,7 @@ module "o11y" {
   app_name                = local.app_name
   prometheus_workspace_id = aws_prometheus_workspace.prometheus.id
   load_balancer_arn       = module.ecs.load_balancer_arn
+  target_group_arn        = module.ecs.target_group_arn
   environment             = terraform.workspace
-  document_db_cluster_id  = module.keystore-docdb.cluster_id
+  docdb_cluster_id        = module.keystore-docdb.cluster_id
 }
-

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -52,24 +52,37 @@ dashboard.new(
 )
 
 .addPanels(layout.generate_grid([
+  //////////////////////////////////////////////////////////////////////////////
   row.new('Application'),
     panels.app.client_registrations(ds, vars)     { gridPos: pos._2 },
     panels.app.dispatched_notifications(ds, vars) { gridPos: pos._2 },
     panels.app.send_failed(ds, vars)              { gridPos: pos._2 },
     panels.app.account_not_found(ds, vars)        { gridPos: pos._2 },
 
+  //////////////////////////////////////////////////////////////////////////////
   row.new('ECS'),
     panels.ecs.cpu(ds, vars)                      { gridPos: pos._2 },
     panels.ecs.memory(ds, vars)                   { gridPos: pos._2 },
 
+  //////////////////////////////////////////////////////////////////////////////
   row.new('Database'),
-    panels.db.available_memory(ds, vars)          { gridPos: pos._2 },
-    panels.db.cpu(ds, vars)                       { gridPos: pos._2 },
+    panels.db.available_memory(ds, vars)          { gridPos: pos._3 },
+    panels.db.cpu(ds, vars)                       { gridPos: pos._3 },
+    panels.db.connections(ds, vars)               { gridPos: pos._3 },
+
+    panels.db.low_mem_op_throttled(ds, vars)      { gridPos: pos._3 },
+    panels.db.volume(ds, vars)                    { gridPos: pos._3 },
+    panels.db.buffer_cache_hit_ratio(ds, vars)    { gridPos: pos._3 },
+
     panels.db.net_throughput(ds, vars)            { gridPos: pos._2 },
     panels.db.write_latency(ds, vars)             { gridPos: pos._2 },
 
+  //////////////////////////////////////////////////////////////////////////////
   row.new('Load Balancer'),
-    panels.lb.requests(ds, vars)                  { gridPos: pos._1 },
-    panels.lb.error_4xx(ds, vars)                 { gridPos: pos._2 },
-    panels.lb.error_5xx(ds, vars)                 { gridPos: pos._2 },
+    panels.lb.active_connections(ds, vars)        { gridPos: pos._2 },
+    panels.lb.requests(ds, vars)                  { gridPos: pos._2 },
+
+    panels.lb.healthy_hosts(ds, vars)             { gridPos: pos._3 },
+    panels.lb.error_4xx(ds, vars)                 { gridPos: pos._3 },
+    panels.lb.error_5xx(ds, vars)                 { gridPos: pos._3 },
 ]))

--- a/terraform/monitoring/dashboard.tf
+++ b/terraform/monitoring/dashboard.tf
@@ -12,7 +12,8 @@ data "jsonnet_file" "dashboard" {
     notifications    = jsonencode(local.notifications)
     ecs_service_name = "${var.environment}-${var.app_name}-service"
     load_balancer    = local.load_balancer
-    docdb_cluster_id = var.document_db_cluster_id
+    target_group     = local.target_group
+    docdb_cluster_id = var.docdb_cluster_id
   }
 }
 

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -1,6 +1,8 @@
 locals {
   load_balancer = join("/", slice(split("/", var.load_balancer_arn), 1, 4))
 
+  target_group = split(":", var.target_group_arn)[5]
+
   opsgenie_notification_channel = "NNOynGwVz"
   notifications = (
     var.environment == "prod" ?

--- a/terraform/monitoring/panels/db/buffer_cache_hit_ratio.libsonnet
+++ b/terraform/monitoring/panels/db/buffer_cache_hit_ratio.libsonnet
@@ -1,0 +1,34 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+local _configuration = defaults.configuration.timeseries
+  .withUnit('percent')
+  .withSoftLimit(
+    axisSoftMin = 90,
+    axisSoftMax = 100,
+  );
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Buffer Cache Hit Ratio',
+      description = 'See https://docs.aws.amazon.com/documentdb/latest/developerguide/best_practices.html',
+      datasource  = ds.cloudwatch,
+    )
+    .configure(_configuration)
+
+    .addTarget(targets.cloudwatch(
+      alias       = 'Average Cache Hit %',
+      datasource  = ds.cloudwatch,
+      namespace   = 'AWS/DocDB',
+      metricName  = 'BufferCacheHitRatio',
+      statistic   = 'Average',
+      dimensions  = {
+        DBClusterIdentifier: vars.docdb_cluster_id
+      },
+      matchExact  = true,
+    ))
+}

--- a/terraform/monitoring/panels/db/connections.libsonnet
+++ b/terraform/monitoring/panels/db/connections.libsonnet
@@ -1,0 +1,26 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Database Connections',
+      datasource  = ds.cloudwatch,
+    )
+    .configure(defaults.configuration.timeseries)
+
+    .addTarget(targets.cloudwatch(
+      alias       = 'Database Connections',
+      datasource  = ds.cloudwatch,
+      namespace   = 'AWS/DocDB',
+      metricName  = 'DatabaseConnections',
+      statistic   = 'Average',
+      dimensions  = {
+        DBClusterIdentifier: vars.docdb_cluster_id
+      },
+      matchExact  = true,
+    ))
+}

--- a/terraform/monitoring/panels/db/low_mem_op_throttled.libsonnet
+++ b/terraform/monitoring/panels/db/low_mem_op_throttled.libsonnet
@@ -1,0 +1,75 @@
+local grafana         = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults        = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels          = grafana.panels;
+local targets         = grafana.targets;
+local alert           = grafana.alert;
+local alertCondition  = grafana.alertCondition;
+
+local ops_threshold   = 2;
+
+local _configuration  = defaults.configuration.timeseries
+  .withSoftLimit(
+    axisSoftMin = 0,
+    axisSoftMax = 10,
+  )
+  .withThresholdStyle('area')
+  .addOverride(grafana.override.new(
+    name = 'Ops_Max',
+    properties = [{
+      id: 'color',
+      value: {
+        mode: 'fixed',
+        fixedColor: defaults.values.colors.critical
+      }
+    }],
+  ))
+  .addThreshold({
+    color : defaults.values.colors.critical,
+    value : ops_threshold
+  });
+
+
+local ops_alert(vars) = alert.new(
+  namespace     = vars.namespace,
+  name          = "%s DocumentDB LowMem Num Operations Throttled Alert" % vars.environment,
+  message       = "%s DocumentDB LowMem Num Operations Throttled" % vars.environment,
+  period        = '5m',
+  frequency     = '1m',
+  notifications = vars.notifications,
+  conditions    = [
+    alertCondition.new(
+      evaluatorParams = [ ops_threshold ],
+      evaluatorType   = 'gt',
+      operatorType    = 'and',
+      queryRefId      = 'Ops_Max',
+      queryTimeStart  = '5m',
+      queryTimeEnd    = 'now',
+      reducerType     = 'max',
+    ),
+  ]
+);
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'LowMem Num Operations Throttled',
+      datasource  = ds.cloudwatch,
+    )
+    .configure(_configuration)
+
+    .setAlert(ops_alert(vars))
+
+    .addTarget(targets.cloudwatch(
+      alias       = 'LowMem Num Operations Throttled (Avg)',
+      datasource  = ds.cloudwatch,
+      dimensions  = {
+        DBClusterIdentifier: vars.docdb_cluster_id
+      },
+      matchExact  = true,
+      namespace   = 'AWS/DocDB',
+      metricName  = 'LowMemNumOperationsThrottled',
+      statistic   = 'Maximum',
+      refId       = 'Ops_Max',
+    ))
+}

--- a/terraform/monitoring/panels/db/volume.libsonnet
+++ b/terraform/monitoring/panels/db/volume.libsonnet
@@ -1,0 +1,33 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+local _configuration = defaults.configuration.timeseries
+  .withUnit('decbytes')
+  .addThreshold({
+    color : 'red',
+    value : 40000000000000, // 40TB, Max is 64TB.
+  })
+  .withSpanNulls(true);
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'DocumentDB Volume',
+      description = 'Max is 64TB',
+      datasource  = ds.cloudwatch,
+    )
+    .configure(_configuration)
+
+    .addTarget(targets.cloudwatch(
+      datasource  = ds.cloudwatch,
+      namespace   = 'AWS/DocDB',
+      metricName  = 'VolumeBytesUsed',
+      statistic   = 'Maximum',
+      dimensions  = {
+        DBClusterIdentifier: vars.docdb_cluster_id
+      },
+    ))
+}

--- a/terraform/monitoring/panels/lb/active_connections.libsonnet
+++ b/terraform/monitoring/panels/lb/active_connections.libsonnet
@@ -1,0 +1,24 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Active Connections',
+      datasource  = ds.cloudwatch,
+    )
+    .configure(defaults.configuration.timeseries)
+
+    .addTarget(targets.cloudwatch(
+      datasource      = ds.cloudwatch,
+      namespace     = 'AWS/ApplicationELB',
+      metricName    = 'ActiveConnectionCount',
+      dimensions    = {
+        LoadBalancer: vars.load_balancer
+      },
+      statistic     = 'Average',
+    ))
+}

--- a/terraform/monitoring/panels/lb/error_4xx.libsonnet
+++ b/terraform/monitoring/panels/lb/error_4xx.libsonnet
@@ -22,6 +22,7 @@ local _alert(namespace, env, notifications) = grafana.alert.new(
   name          = "%(env)s - 4XX alert"     % { env: grafana.utils.strings.capitalize(env) },
   message       = '%(env)s - Too many 4XX'  % { env: grafana.utils.strings.capitalize(env) },
   notifications = notifications,
+  noDataState   = 'no_data',
   conditions    = [
     grafana.alertCondition.new(
       evaluatorParams = [ threshold ],

--- a/terraform/monitoring/panels/lb/error_5xx.libsonnet
+++ b/terraform/monitoring/panels/lb/error_5xx.libsonnet
@@ -22,6 +22,7 @@ local _alert(namespace, env, notifications) = grafana.alert.new(
   name          = "%(env)s - 5XX alert"     % { env: grafana.utils.strings.capitalize(env) },
   message       = '%(env)s - Too many 5XX'  % { env: grafana.utils.strings.capitalize(env) },
   notifications = notifications,
+  noDataState   = 'no_data',
   conditions    = [
     grafana.alertCondition.new(
       evaluatorParams = [ threshold ],

--- a/terraform/monitoring/panels/lb/healthy_hosts.libsonnet
+++ b/terraform/monitoring/panels/lb/healthy_hosts.libsonnet
@@ -1,0 +1,68 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+local _configuration = defaults.configuration.timeseries
+  .withSoftLimit(
+    axisSoftMin = 0,
+    axisSoftMax = 5,
+  );
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Healthy Hosts',
+      datasource  = ds.cloudwatch,
+    )
+    .configure(_configuration)
+
+    .addTarget(targets.cloudwatch(
+      datasource      = ds.cloudwatch,
+      metricQueryType = grafana.target.cloudwatch.metricQueryTypes.query,
+
+      dimensions    = {
+        TargetGroup: vars.target_group
+      },
+      metricName    = 'HealthyHostCount',
+      namespace     = 'AWS/ApplicationELB',
+      sql           = {
+        from: {
+          property: {
+            name: "AWS/ApplicationELB",
+            type: "string"
+          },
+          type: "property"
+        },
+        select: {
+          name: "MAX",
+          parameters: [
+            {
+              name: "HealthyHostCount",
+              type: "functionParameter"
+            }
+          ],
+          type: "function"
+        },
+        where: {
+          expressions: [
+            {
+              operator: {
+                name: "=",
+                value: vars.load_balancer
+              },
+              property: {
+                name: "LoadBalancer",
+                type: "string"
+              },
+              type: "operator"
+            }
+          ],
+          type: "and"
+        }
+      },
+      sqlExpression = "SELECT MAX(HealthyHostCount) FROM \"AWS/ApplicationELB\" WHERE LoadBalancer = '%s'" % [vars.load_balancer],
+      statistic     = 'Maximum',
+    ))
+}

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -7,8 +7,12 @@
   },
   db: {
     available_memory:         (import 'db/available_memory.libsonnet'           ).new,
+    buffer_cache_hit_ratio:   (import 'db/buffer_cache_hit_ratio.libsonnet'     ).new,
+    connections:              (import 'db/connections.libsonnet'                ).new,
     cpu:                      (import 'db/cpu.libsonnet'                        ).new,
+    low_mem_op_throttled:     (import 'db/low_mem_op_throttled.libsonnet'       ).new,
     net_throughput:           (import 'db/net_throughput.libsonnet'             ).new,
+    volume:                   (import 'db/volume.libsonnet'                     ).new,
     write_latency:            (import 'db/write_latency.libsonnet'              ).new,
   },
   ecs: {
@@ -16,8 +20,10 @@
     memory:                   (import 'ecs/memory.libsonnet'                    ).new,
   },
   lb: {
-    requests:                 (import 'lb/requests.libsonnet'                   ).new,
+    active_connections:       (import 'lb/active_connections.libsonnet'         ).new,
     error_4xx:                (import 'lb/error_4xx.libsonnet'                  ).new,
     error_5xx:                (import 'lb/error_5xx.libsonnet'                  ).new,
+    healthy_hosts:            (import 'lb/healthy_hosts.libsonnet'              ).new,
+    requests:                 (import 'lb/requests.libsonnet'                   ).new,
   },
 }

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -7,13 +7,21 @@ variable "app_name" {
 }
 
 variable "prometheus_workspace_id" {
-  type = string
+  description = "The workspace ID for the Prometheus workspace."
+  type        = string
+}
+
+variable "target_group_arn" {
+  description = "The ARN of the target group."
+  type        = string
 }
 
 variable "load_balancer_arn" {
-  type = string
+  description = "The ARN of the load balancer."
+  type        = string
 }
 
-variable "document_db_cluster_id" {
-  type = string
+variable "docdb_cluster_id" {
+  description = "The ID of the DocumentDB cluster."
+  type        = string
 }


### PR DESCRIPTION
# Description

- Add ELB:
  - Active Connections
  - Healthy Hosts
- Add DocDB panels
  - Buffer cache hit ration
  - Database Connections
  - LowMem Num Operations Throttled
  - Volume
- Remove `no-data` alerts for 4XX and 5XX

Resolves #36 

## How Has This Been Tested?

Manual run of `jsonnet`

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
