### PR TITLE
fix: recconnect to relay after error

### DIFF
--- a/src/websocket_service/mod.rs
+++ b/src/websocket_service/mod.rs
@@ -73,7 +73,7 @@ impl WebsocketService {
                 wsclient::RelayClientEvent::Error(e) => {
                     warn!("Received error from relay: {}", e);
                     while let Err(e) = self.connect().await {
-                        warn!("Error reconnecting to relay: {}", e);
+                        error!("Error reconnecting to relay: {}", e);
                         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                     }
                 }

--- a/src/websocket_service/mod.rs
+++ b/src/websocket_service/mod.rs
@@ -72,6 +72,10 @@ impl WebsocketService {
                 }
                 wsclient::RelayClientEvent::Error(e) => {
                     warn!("Received error from relay: {}", e);
+                    while let Err(e) = self.connect().await {
+                        warn!("Error reconnecting to relay: {}", e);
+                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                    }
                 }
                 wsclient::RelayClientEvent::Disconnected(_) => {
                     while let Err(e) = self.connect().await {


### PR DESCRIPTION
# Description

Small change adding reconnection logic after error form relay.

Resolves #76 

## How Has This Been Tested?

Tested with force-closing and restarting local relay.
![image](https://github.com/WalletConnect/cast-server/assets/38994251/41730193-99dc-4fb3-8829-780e8dbc55da)


## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
