### PR TITLE
fix: add noop message to relay to triger extension of topic

### DIFF
--- a/src/websocket_service/handlers/push_subscribe.rs
+++ b/src/websocket_service/handlers/push_subscribe.rs
@@ -84,7 +84,7 @@ pub async fn handle(
             response_topic.into(),
             base64_notification,
             4007,
-            Duration::from_secs(300),
+            Duration::from_secs(86400),
             false,
         )
         .await?;
@@ -106,13 +106,7 @@ pub async fn handle(
     // extended
     info!("[{request_id}] Sending settle message");
     client
-        .publish(
-            push_topic.into(),
-            "",
-            4050,
-            Duration::from_secs(86400),
-            false,
-        )
+        .publish(push_topic.into(), "", 4050, Duration::from_secs(300), false)
         .await?;
 
     state

--- a/src/websocket_service/handlers/push_subscribe.rs
+++ b/src/websocket_service/handlers/push_subscribe.rs
@@ -84,7 +84,7 @@ pub async fn handle(
             response_topic.into(),
             base64_notification,
             4007,
-            Duration::from_secs(86400),
+            Duration::from_secs(300),
             false,
         )
         .await?;

--- a/src/websocket_service/handlers/push_subscribe.rs
+++ b/src/websocket_service/handlers/push_subscribe.rs
@@ -104,7 +104,11 @@ pub async fn handle(
 
     // This noop message is making relay aware that this topics TTL should be
     // extended
-    info!("[{request_id}] Sending settle message");
+    info!(
+        "[{request_id}] Sending settle message on topic {}",
+        &push_topic
+    );
+
     client
         .publish(push_topic.into(), "", 4050, Duration::from_secs(300), false)
         .await?;


### PR DESCRIPTION
# Description

Adding noop message in subscribe flow to trigger topping mapping extension in relay.

Resolves #92 

## How Has This Been Tested?

Tests passing.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
