### PR TITLE
fix(hotfix): Cast not subscribed when sending message

### DIFF
--- a/src/websocket_service/handlers/push_subscribe.rs
+++ b/src/websocket_service/handlers/push_subscribe.rs
@@ -109,12 +109,16 @@ pub async fn handle(
         &push_topic
     );
 
-    client
-        .subscribe(push_topic.clone().into())
-        .await?;
+    client.subscribe(push_topic.clone().into()).await?;
 
     client
-        .publish(push_topic.clone().into(), "", 4050, Duration::from_secs(300), false)
+        .publish(
+            push_topic.clone().into(),
+            "",
+            4050,
+            Duration::from_secs(300),
+            false,
+        )
         .await?;
 
     state
@@ -125,10 +129,10 @@ pub async fn handle(
         )
         .await?;
 
-        info!(
-            "[{request_id}] Settle message sent on topic {}",
-            &push_topic
-        );
+    info!(
+        "[{request_id}] Settle message sent on topic {}",
+        &push_topic
+    );
 
     Ok(())
 }

--- a/src/websocket_service/handlers/push_subscribe.rs
+++ b/src/websocket_service/handlers/push_subscribe.rs
@@ -110,7 +110,11 @@ pub async fn handle(
     );
 
     client
-        .publish(push_topic.into(), "", 4050, Duration::from_secs(300), false)
+        .subscribe(push_topic.clone().into())
+        .await?;
+
+    client
+        .publish(push_topic.clone().into(), "", 4050, Duration::from_secs(300), false)
         .await?;
 
     state
@@ -120,6 +124,11 @@ pub async fn handle(
             &url::Url::parse(&state.config.relay_url)?,
         )
         .await?;
+
+        info!(
+            "[{request_id}] Settle message sent on topic {}",
+            &push_topic
+        );
 
     Ok(())
 }


### PR DESCRIPTION
# Description

Cast is not subscribed to the topic it sending a message to. Hence, Relay cannot extend it's expiration as the routing table record does not exist.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
