### PR TITLE
fix: lookup data not being replaced properly and legacy defaults

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -27,23 +27,9 @@ pub struct SubscriptionAuth {
     /// (did:pkh)
     pub sub: String,
     /// act - description of action intent. Must be equal to "push_subscription"
-    #[serde(default = "default_act")]
     pub act: String,
     /// scp - scope of notification types authorized by the user
-    #[serde(default = "default_scope")]
     pub scp: String,
-}
-
-// TODO: Remove this as soon as wc_pushRequest -> wc_pushSubscribe migration is
-// done
-fn default_scope() -> String {
-    "gm_hourly".to_string()
-}
-
-// TODO: Remove this as soon as wc_pushRequest -> wc_pushSubscribe migration is
-// done
-fn default_act() -> String {
-    "push_subscription".to_string()
 }
 
 impl SubscriptionAuth {

--- a/src/state.rs
+++ b/src/state.rs
@@ -81,7 +81,7 @@ impl AppState {
         self.database
             .collection::<LookupEntry>("lookup_table")
             .replace_one(
-                doc! { "_id": &topic},
+                doc! { "topic": &topic, "project_id": &project_id.to_string()},
                 LookupEntry {
                     topic: topic.clone(),
                     project_id: project_id.to_string(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -31,16 +31,7 @@ pub struct ClientData {
     pub id: String,
     pub relay_url: String,
     pub sym_key: String,
-    #[serde(default = "default_scope")]
     pub scope: HashSet<String>,
-}
-
-// TODO: Remove this as soon as wc_pushRequest -> wc_pushSubscribe migration is
-// done
-fn default_scope() -> HashSet<String> {
-    let mut scope = HashSet::with_capacity(1);
-    scope.insert("gm_hourly".into());
-    scope
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -173,12 +164,5 @@ pub struct Notification {
     pub body: String,
     pub icon: String,
     pub url: String,
-    #[serde(default = "default_notification_type")]
     pub r#type: String,
-}
-
-// TODO: Remove this as soon as wc_pushRequest -> wc_pushSubscribe migration is
-// done
-fn default_notification_type() -> String {
-    "gm_hourly".to_string()
 }


### PR DESCRIPTION
# Description

Code had some defaults that were used for compatibility during stage 1 work.
Not required anymore.

Also fixing a bug where updating/resubscribing an account would create new record in `lookup_table` instead of modifying the last one, allowing the old topic to still be used. They should now be replaced properly.

Resolves #102 

## How Has This Been Tested?

Integ testspass.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
